### PR TITLE
Fix h11 dependency version pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: '{{ PYTHON }} -m pip install . -vv '
 
 requirements:
@@ -20,7 +20,7 @@ requirements:
     - python >=3.6
     - setuptools
   run:
-    - h11 ==0.*
+    - h11 >=0.11,<0.13
     - h2 >=3,<5
     - python >=3.6
     - sniffio ==1.*


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This change now matches [the upstream version pin](https://github.com/encode/httpcore/blob/0.13.3/setup.py#L56).

Without this, one of my environments pulled in h11 0.9.0 and caused a deadlock in a docker environment.  Upgrading h11 to the recommended version fixed the deadlock.